### PR TITLE
Use fork of aws.signature to enable refreshable credentials

### DIFF
--- a/R/aws_helper_functions.R
+++ b/R/aws_helper_functions.R
@@ -7,11 +7,14 @@
 #' @examples s3.buckets()
 #'
 accessible_buckets <- function(accessible=TRUE){
+  credentials <- aws.signature::get_credentials()
 
   check_access <- function(bucket_name){
+      suppressMessages(refresh(credentials))
       suppressMessages(aws.s3::bucket_exists(bucket_name))[1]
   }
 
+  refresh(credentials)
   bucket_list <- aws.s3::bucketlist()
   bucket_list <- bucket_list$Bucket
   access <- purrr::map_lgl(bucket_list, check_access)
@@ -52,6 +55,8 @@ accessible_files_df <- function(){
     df
   }
 
+  credentials <- aws.signature::get_credentials()
+  refresh(credentials)
   accessible_buckets() %>%
     purrr::map(aws.s3::get_bucket) %>%
     purrr::keep(function(x) {length(x) > 0}) %>%

--- a/R/parse_s3_data.R
+++ b/R/parse_s3_data.R
@@ -16,11 +16,14 @@ separate_bucket_path <- function(path) {
 #' @examples df <- s3_read_path_to_df("alpha-moj-analytics-scratch/a/b/c/robins_temp.csv")
 s3_path_to_df <- function(path, head=TRUE) {
   p <- separate_bucket_path(path)
+  credentials <- aws.signature::get_credentials()
   if (head) {
+    refresh(credentials)
     ob <- aws.s3::get_object(p$object, p$bucket,  headers = list(Range='bytes=0-12000'))
     df <- read.csv(text = rawToChar(ob))
     df <- head(df)
   } else {
+    refresh(credentials)
     ob <- aws.s3::get_object(p$object, p$bucket)
     df <- read.csv(text = rawToChar(ob))
   }

--- a/R/write_to_s3.R
+++ b/R/write_to_s3.R
@@ -14,6 +14,8 @@ write_df_to_csv_in_s3 <- function(df, filename, bucket) {
   write.csv(df, rc)
 
   # upload the object to S3
+  credentials <- aws.signature::get_credentials()
+  refresh(credentials)
   aws.s3::put_object(file = rawConnectionValue(rc), bucket = bucket, object = filename)
 
   # close the connection


### PR DESCRIPTION
Uses https://github.com/ministryofjustice/aws.signature/tree/credentials-resolver to transparently fetch temporary AWS credentials from the EC2 metadata and refresh them automatically when they expire.