### PR TITLE
Anaconda: Fix for pushing package on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,20 @@ jobs:
 
 workflows:
   version: 2
-
-  build_and_publish:
+  build-only:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              ignore: /^v.*/
+  build-and-publish:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - publish:
           filters:
             tags:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: s3tools
 Title: Tools to help explore Amazon S3
-Version: 0.0.8
+Version: 0.0.9
 Authors@R: c(person("Will", "Bowditch", email = "william.bowditch@digital.justice.gov.uk", role = c("aut")),person("Robin", "Linacre", email = "Robin.Linacre@digital.justice.gov.uk", role = c("aut", "cre")))
 Description: Tools to help explore Amazon S3
 Depends: R (>= 3.3.2)


### PR DESCRIPTION
This will ensure that a new build is pushed to anaconda on a github release.

Version bumped to 0.0.9 to allow for checking this works