### PR TITLE
Stop errors printing again

### DIFF
--- a/R/aws.R
+++ b/R/aws.R
@@ -34,7 +34,6 @@ get_role_policy <- function(policy_name, role_name) {
   result <- request$execute()
 
   if (!is.null(result$Error)) {
-    print(result)
     return(result)
   }
 


### PR DESCRIPTION
The print function means that when used within TryCatch the error is still printed... which is annoying. Error should print any when it occurs if not in a TryCatch... I think.