### PR TITLE
quick fix for function

### DIFF
--- a/R/write_to_s3.R
+++ b/R/write_to_s3.R
@@ -23,12 +23,24 @@ write_df_to_csv_in_s3 <- function(df, s3_path, overwrite=FALSE, multipart=TRUE, 
   if (overwrite || !(s3_file_exists(s3_path))) {
     rcv <- rawConnectionValue(rc)
     close(rc)
-    return(aws.s3::put_object(what = rcv,
-                       bucket = p$bucket,
-                       object = p$object,
-                       check_region = TRUE,
-                       multipart = multipart,
-                       headers = c('x-amz-server-side-encryption' = 'AES256')))
+    # check aws package version of user
+    if(packageVersion("aws.s3")>"0.3.21") {
+      return(aws.s3::put_object(what = rcv,
+                                bucket = p$bucket,
+                                object = p$object,
+                                check_region = TRUE,
+                                multipart = multipart,
+                                headers = c('x-amz-server-side-encryption' = 'AES256')))
+    } else {
+      return(aws.s3::put_object(file = rcv,
+                                bucket = p$bucket,
+                                object = p$object,
+                                check_region = TRUE,
+                                multipart = multipart,
+                                headers = c('x-amz-server-side-encryption' = 'AES256')))
+    }
+    
+
   } else {
     close(rc)
     stop("File already exists and you haven't set overwrite = TRUE, stopping")

--- a/R/write_to_s3.R
+++ b/R/write_to_s3.R
@@ -18,11 +18,12 @@ write_df_to_csv_in_s3 <- function(df, s3_path, overwrite=FALSE, multipart=TRUE, 
   suppressMessages(refresh(credentials))
   
   p <- separate_bucket_path(s3_path)
+  if(grepl('^NA', p$object, fixed = FALSE)) stop('Invalid s3_path entered. Please ensure the path contains your filename.')
   
   if (overwrite || !(s3_file_exists(s3_path))) {
     rcv <- rawConnectionValue(rc)
     close(rc)
-    return(aws.s3::put_object(file = rcv,
+    return(aws.s3::put_object(what = rcv,
                        bucket = p$bucket,
                        object = p$object,
                        check_region = TRUE,


### PR DESCRIPTION
I should note that this fix only works for the latest version of `aws.s3` - version **0.3.22**. Users running off version **0.3.21** will have s3tools work as expected. 

renv users now get the following error when trying to use the original `s3tools::write_df_to_csv_in_s3` function
![Screenshot 2021-08-03 at 17 31 47](https://user-images.githubusercontent.com/45356472/128052441-da72e49c-b21d-48c3-8356-34a8eed8f167.png)

The below should resolve the issue. It looks like the issue has arisen due to amazon (or whoever is maintaing aws.s3) changing their `aws.s3::put_object` function, such that it now checks the file size of our rawConnection object and falls over. 

You can recreate this error using:
```
rc <- rawConnection(raw(0), "r+")
write.csv(data.frame(x = 1:3), rc)
file.size(rc)
```

I've also added in some quick regex to ensure the user enters a valid filepath. If you simply enter an s3 bucket name, you'll find a filepath of `NA/entered_filepath` when you browse to your S3 bucket.